### PR TITLE
Fixes compile errors for implicit instantiation on osx

### DIFF
--- a/src/debugger/rewind-window.cc
+++ b/src/debugger/rewind-window.cc
@@ -5,6 +5,7 @@
  * of the MIT license.  See the LICENSE file for details.
  */
 #include "debugger.h"
+#include <string>
 
 #include <inttypes.h>
 

--- a/src/debugger/rom-window.cc
+++ b/src/debugger/rom-window.cc
@@ -10,6 +10,8 @@
 #include "imgui_dock.h"
 #include "imgui-helpers.h"
 
+#include <string>
+
 Debugger::ROMWindow::ROMWindow(Debugger* d) : Window(d) {}
 
 void Debugger::ROMWindow::Init() {

--- a/src/tester.c
+++ b/src/tester.c
@@ -7,6 +7,7 @@
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
+#include <inttypes.h>
 
 #ifndef _MSC_VER
 #include <sys/time.h>
@@ -285,7 +286,7 @@ void print_ops(void) {
     printf("  ...\n");
   }
   printf("distinct: %d\n", distinct);
-  printf("total: %llu\n", total);
+  printf("total: %" PRIu64 "\n", total);
 }
 
 void swap_pair(U32Pair* a, U32Pair* b) {

--- a/src/tester.c
+++ b/src/tester.c
@@ -285,7 +285,7 @@ void print_ops(void) {
     printf("  ...\n");
   }
   printf("distinct: %d\n", distinct);
-  printf("total: %lu\n", total);
+  printf("total: %llu\n", total);
 }
 
 void swap_pair(U32Pair* a, U32Pair* b) {


### PR DESCRIPTION
I was trying to build on OSX this weekend and ran into a couple of compilation errors (warning I am NOT experienced at C or C++ so totally understand if there is something else going on here). This diff fixes the issue on my machine (OSX 10.13.6 high sierra)

```
Apple LLVM version 10.0.0 (clang-1000.11.45.5)
Target: x86_64-apple-darwin17.7.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```

```bash
[master]? % make                             
/Applications/Xcode.app/Contents/Developer/usr/bin/make --no-print-directory -C out/Debug
[ 16%] Built target binjgb-tester
[ 16%] Built target binjgb-tester-copy-to-bin
Scanning dependencies of target binjgb-debugger
[ 18%] Building CXX object CMakeFiles/binjgb-debugger.dir/src/debugger/rewind-window.cc.o
[ 20%] Building CXX object CMakeFiles/binjgb-debugger.dir/src/debugger/rom-window.cc.o
/Users/anders/Projects/binjgb/src/debugger/rom-window.cc:61:41: error: implicit instantiation of undefined template
      'std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >'
    ImGui::Text("Unknown: %s (%.0f%%)", d->PrettySize(usage_bytes[0]).c_str(),
                                        ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/iosfwd:193:32: note: 
      template is declared here
    class _LIBCPP_TEMPLATE_VIS basic_string;
                               ^
/Users/anders/Projects/binjgb/src/debugger/rom-window.cc:63:38: error: implicit instantiation of undefined template
      'std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >'
    ImGui::Text("Data: %s (%.0f%%)", d->PrettySize(usage_bytes[2]).c_str(),
                                     ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/iosfwd:193:32: note: 
      template is declared here
    class _LIBCPP_TEMPLATE_VIS basic_string;
                               ^
/Users/anders/Projects/binjgb/src/debugger/rom-window.cc:65:38: error: implicit instantiation of undefined template
      'std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >'
    ImGui::Text("Code: %s (%.0f%%)", d->PrettySize(usage_bytes[3]).c_str(),
                                     ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/iosfwd:193:32: note: 
      template is declared here
    class _LIBCPP_TEMPLATE_VIS basic_string;
```
