### PR TITLE
Prepend shader version; avoid deprecated features

### DIFF
--- a/src/host-gl.c
+++ b/src/host-gl.c
@@ -35,7 +35,11 @@ Result host_gl_init_procs(void) {
 Result host_gl_shader(GLenum type, const GLchar* source, GLuint* out_shader) {
   assert(type == GL_VERTEX_SHADER || type == GL_FRAGMENT_SHADER);
   GLuint shader = glCreateShader(type);
-  glShaderSource(shader, 1, &source, NULL);
+  char version[128];
+  snprintf(version, sizeof(version) - 1, "#version %d\n",
+           host_gl_shader_version());
+  const GLchar* sources[] = {version, source};
+  glShaderSource(shader, 2, sources, NULL);
   glCompileShader(shader);
   CHECK_LOG(shader, Shader, GL_COMPILE_STATUS, type == GL_VERTEX_SHADER
                                                    ? "GL_VERTEX_SHADER"
@@ -55,4 +59,11 @@ Result host_gl_program(GLuint vert_shader, GLuint frag_shader,
   *out_program = program;
   return OK;
   ON_ERROR_RETURN;
+}
+
+int host_gl_shader_version(void) {
+  const GLubyte* string = glGetString(GL_SHADING_LANGUAGE_VERSION);
+  int major, minor;
+  sscanf((const char*)string, "%d.%d", &major, &minor);
+  return major * 100 + minor;
 }

--- a/src/host-gl.h
+++ b/src/host-gl.h
@@ -49,6 +49,7 @@ Result host_gl_init_procs(void);
 Result host_gl_shader(GLenum type, const GLchar* source, GLuint* out_shader);
 Result host_gl_program(GLuint vert_shader, GLuint frag_shader,
                        GLuint* out_program);
+int host_gl_shader_version(void);  // e.g. 1.30 is returned as 130.
 
 #ifdef __cplusplus
 }

--- a/src/host-ui-imgui.cc
+++ b/src/host-ui-imgui.cc
@@ -113,12 +113,11 @@ Result HostUI::init() {
 
 Result HostUI::init_gl() {
   static const char* s_vertex_shader =
-      "#version 130\n"
-      "attribute vec2 aPos;\n"
-      "attribute vec2 aUV;\n"
-      "attribute vec4 aColor;\n"
-      "varying vec2 vUV;\n"
-      "varying vec4 vColor;\n"
+      "in vec2 aPos;\n"
+      "in vec2 aUV;\n"
+      "in vec4 aColor;\n"
+      "out vec2 vUV;\n"
+      "out vec4 vColor;\n"
       "uniform mat3 uProjMatrix;\n"
       "void main(void) {\n"
       "  gl_Position = vec4(uProjMatrix * vec3(aPos, 1.0), 1.0);\n"
@@ -127,9 +126,9 @@ Result HostUI::init_gl() {
       "}\n";
 
   static const char* s_fragment_shader =
-      "#version 130\n"
-      "varying vec2 vUV;\n"
-      "varying vec4 vColor;\n"
+      "in vec2 vUV;\n"
+      "in vec4 vColor;\n"
+      "out vec4 oColor;\n"
       "uniform int uUsePalette;\n"
       "uniform vec4 uPalette[4];\n"
       "uniform sampler2D uSampler;\n"
@@ -138,7 +137,7 @@ Result HostUI::init_gl() {
       "  if (uUsePalette != 0) {\n"
       "    color = uPalette[int(clamp(color.x * 256.0, 0.0, 3.0))];\n"
       "  }\n"
-      "  gl_FragColor = color;\n"
+      "  oColor = color;\n"
       "}\n";
 
   glGenBuffers(1, &vbo);

--- a/src/host-ui-simple.c
+++ b/src/host-ui-simple.c
@@ -34,18 +34,17 @@ static Result host_ui_init(struct HostUI* ui, SDL_Window* window) {
   };
 
   static const char* s_vertex_shader =
-      "#version 130\n"
-      "attribute vec2 aPos;\n"
-      "attribute vec2 aTexCoord;\n"
-      "varying vec2 vTexCoord;\n"
+      "in vec2 aPos;\n"
+      "in vec2 aTexCoord;\n"
+      "out vec2 vTexCoord;\n"
       "void main(void) {\n"
       "  gl_Position = vec4(aPos, 0.0, 1.0);\n"
       "  vTexCoord = aTexCoord;\n"
       "}\n";
 
   static const char* s_fragment_shader =
-      "#version 130\n"
-      "varying vec2 vTexCoord;\n"
+      "in vec2 vTexCoord;\n"
+      "out vec4 oColor;\n"
       "uniform int uUsePalette;\n"
       "uniform vec4 uPalette[4];\n"
       "uniform sampler2D uSampler;\n"
@@ -54,7 +53,7 @@ static Result host_ui_init(struct HostUI* ui, SDL_Window* window) {
       "  if (uUsePalette != 0) {\n"
       "    color = uPalette[int(clamp(color.x * 256.0, 0.0, 3.0))];\n"
       "  }\n"
-      "  gl_FragColor = color;\n"
+      "  oColor = color;\n"
       "}\n";
 
   ui->window = window;


### PR DESCRIPTION
OSX seems to want shader version 150, instead of 130. Since we require
OpenGL 3, I think it's enough to support 150 and always use the version
tag that matches the value returned from GL_SHADING_LANGUAGE_VERSION.

Should fix issue #16.