### PR TITLE
Fix web demo buttons

### DIFF
--- a/demo.js
+++ b/demo.js
@@ -71,7 +71,7 @@ let vm = new Vue({
   data: data,
   created: function() {
     setInterval(() => {
-      this.fps = emulator ? emulator.fps : 60;
+      this.fps = emulator ? emulator.formatFPS() : "60.0";
     }, 500);
     setInterval(() => {
       if (this.extRamUpdated) {
@@ -419,6 +419,12 @@ class Emulator {
 
   get ticks() {
     return this.module._emulator_get_ticks_f64(this.e);
+  }
+
+  formatFPS() {
+    const wholeDigits = Math.floor(Math.log10(this.fps)) + 1;
+    const precision = 3 - wholeDigits;
+    return this.fps.toFixed(precision > 0 ? precision : 0);
   }
 
   runUntil(ticks) {

--- a/index.html
+++ b/index.html
@@ -236,7 +236,7 @@
               @click="togglePause">{{pauseLabel}}</button>
         </div>
         <div class="right">
-          <span>{{fps.toFixed(1)}}</span> FPS
+          <span>{{fps}}</span> FPS
         </div>
       </div>
       <div v-if="loaded && paused">

--- a/index.html
+++ b/index.html
@@ -134,7 +134,7 @@
     }
     .bar {
       display: grid;
-      width: 800px;
+      width: 850px;
       margin: auto;
       grid-template-columns: auto 1fr auto;
     }


### PR DESCRIPTION
In the web version of the emulator, the buttons at the bottom become too wide when the FPS goes into the triple-digits, or when the pause button is replaced by a resume button.

![screenshot demonstrating the too-long bar](https://user-images.githubusercontent.com/553637/57092654-22a84900-6d0c-11e9-987b-0de961ae7ab2.png)

This PR truncates FPS under 1000 to three sigfigs, and rounds FPS over 1000 to the nearest integer. It also slightly increases the bar width to account for the resume button.