### PR TITLE
Support Windows in build_tests.py

### DIFF
--- a/scripts/build_tests.py
+++ b/scripts/build_tests.py
@@ -41,13 +41,23 @@ def GitUpdate(repo, dirname, sha):
     Run('git', 'clone', repo, dirname)
   Run('git', 'checkout', sha, cwd=dirname)
 
+def NMakeFound():
+  for path in os.environ["PATH"].split(os.pathsep):
+    nmake = os.path.join(path, 'nmake.exe')
+    if os.path.isfile(nmake):
+      return True
+  return False
 
 def BuildWlaGb():
   GitUpdate(WLA_DX_GIT_REPO, WLA_DX_DIR, WLA_DX_GIT_SHA)
   if not os.path.exists(WLA_DX_BUILD_DIR):
     os.makedirs(WLA_DX_BUILD_DIR)
-  Run('cmake', WLA_DX_DIR, cwd=WLA_DX_BUILD_DIR)
-  Run('make', cwd=WLA_DX_BUILD_DIR)
+  if NMakeFound():
+    Run('cmake', '-G', 'NMake Makefiles', '-DCMAKE_BUILD_TYPE=Release', WLA_DX_DIR, cwd=WLA_DX_BUILD_DIR)
+    Run('nmake', cwd=WLA_DX_BUILD_DIR)
+  else:
+    Run('cmake', WLA_DX_DIR, cwd=WLA_DX_BUILD_DIR)
+    Run('make', cwd=WLA_DX_BUILD_DIR)
   # Test that wla-gb was build OK.
   Run(os.path.join(WLA_DX_BIN_DIR, 'wla-gb'))
 

--- a/scripts/build_tests.py
+++ b/scripts/build_tests.py
@@ -52,7 +52,7 @@ def BuildWlaGb():
   GitUpdate(WLA_DX_GIT_REPO, WLA_DX_DIR, WLA_DX_GIT_SHA)
   if not os.path.exists(WLA_DX_BUILD_DIR):
     os.makedirs(WLA_DX_BUILD_DIR)
-  if NMakeFound():
+  if (sys.platform == 'win32') and NMakeFound():
     Run('cmake', '-G', 'NMake Makefiles', '-DCMAKE_BUILD_TYPE=Release', WLA_DX_DIR, cwd=WLA_DX_BUILD_DIR)
     Run('nmake', cwd=WLA_DX_BUILD_DIR)
   else:


### PR DESCRIPTION
Before this change, when build_tests.py was invoked under a Visual Studio command prompt, CMake would generate NMake makefiles by default, but then the script would call standard Make, which would fail because it doesn't understand NMake makefiles.

To fix this situation, when build_tests.py is invoked let's check if NMake exists. It it exists, let CMake generate NMake makefiles and then call NMake.

NOTE: Someone might suggest to tell CMake to always generate Unix Makefiles (even on Windows) and then call standard Make on them. Unfortunately that wouldn't work on Windows, because these makefiles would represent paths using forward slashes, and the Microsoft compiler wouldn't understand them.