### PR TITLE
Upload wasm build as artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,3 +97,8 @@ jobs:
       run: |
         source $HOME/emsdk/emsdk_env.sh
         cmake --build out
+        
+    - uses: actions/upload-artifact@v3
+      with:
+        name: wasm-build
+        path: out/


### PR DESCRIPTION
Just a quick change to expose the results of the wasm build in the CI as artifact so the js and wasm files can be easily downloaded 

I can also do this for every build target, let me know  how this looks @binji :smile: 