### PR TITLE
Allow passing cmake flags to make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ out/$1:
 	mkdir -p out/$1
 out/$1/Makefile: | out/$1
 	cd out/$1 && \
-		cmake ../.. -DCMAKE_TOOLCHAIN_FILE=$(EMSCRIPTEN_CMAKE) \
+		cmake ../.. ${CMAKEFLAGS} -DCMAKE_TOOLCHAIN_FILE=$(EMSCRIPTEN_CMAKE) \
 								-DCMAKE_BUILD_TYPE=Release \
 								-DWERROR=ON $3
 .PHONY: $2


### PR DESCRIPTION
Hey, 

I was trying to find a way to pass the new `RGBDS_LIVE` flag but I couldn't figure out how without modifying the Makefile (or calling cmake directly).

This is a simple modification allowing to pass additional flags to the EMSCRIPTEN_BUILD rule.

E.g., it makes this possible:

```
make wasm CMAKEFLAGS="-DRGBDS_LIVE=ON" EMSCRIPTEN_DIR=${EMSDK}/upstream/emscripten
```

Not passing any CMAKEFLAGS variable will also work so I don't think it's breaking anything.

Only thing I was wondering if the same should be done to the standard build rule (BUILD).



Thanks to @ISSOtm for the help on this