### PR TITLE
Expose mute channel functionality to WASM build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,7 +153,6 @@ else (EMSCRIPTEN)
   endif ()
 
   set(LINK_FLAGS
-    --memory-init-file 0
     -s EXPORTED_FUNCTIONS=\"@${EXPORTED_JSON}\"
     -s MALLOC=emmalloc
     -s ASSERTIONS=0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/cmake)
 option(WERROR "Build with warnings as errors" OFF)
 option(WASM "Build for WebAssembly" OFF)
 option(RGBDS_LIVE "Build for rgbds-live (Wasm only)" OFF)
+option(GBSTUDIO "Build for GB Studio (Wasm only. Sets rgbds-live.)" OFF)
 
 if (MSVC)
   add_definitions(-W3 -D_CRT_SECURE_NO_WARNINGS)
@@ -150,6 +151,11 @@ else (EMSCRIPTEN)
 
   if (RGBDS_LIVE)
     target_compile_definitions(binjgb PUBLIC RGBDS_LIVE)
+  endif ()
+
+  if (GBSTUDIO)
+    # If GBSTUDIO is set, set RGBDS_LIVE too
+    target_compile_definitions(binjgb PUBLIC GBSTUDIO RGBDS_LIVE)
   endif ()
 
   set(LINK_FLAGS

--- a/src/emscripten/exported.json
+++ b/src/emscripten/exported.json
@@ -59,5 +59,6 @@
 "_emulator_get_wram_ptr",
 "_emulator_get_hram_ptr",
 "_emulator_read_mem",
-"_emulator_write_mem"
+"_emulator_write_mem",
+"_set_audio_channel_mute"
 ]

--- a/src/emulator.c
+++ b/src/emulator.c
@@ -5258,3 +5258,19 @@ void emulator_render_vram(Emulator* e, u32* buffer) {}
 void emulator_render_background(Emulator* e, u32* buffer, int type) {}
 
 #endif
+
+#ifdef GBSTUDIO
+Bool set_audio_channel_mute(Emulator *e, int channel, Bool muted) {
+  EmulatorConfig emu_config = emulator_get_config(e);
+  emu_config.disable_sound[channel] = muted;
+  emulator_set_config(e, &emu_config);
+  return emu_config.disable_sound[channel];
+}
+
+#else  // !GBSTUDIO
+
+Bool set_audio_channel_mute(Emulator *e, int channel, Bool muted) { 
+  return FALSE;
+}
+
+#endif


### PR DESCRIPTION
This is used by the GB Studio tracker. 

Until now I was using a forked version of binjgb in GB Studio but would be good to use the upstream one as much as possible. I followed the same pattern as the rgbds-live functionality to setup the function visibility.

