### PR TITLE
Fix compiler warning.

### DIFF
--- a/src/debugger/io-window.cc
+++ b/src/debugger/io-window.cc
@@ -55,7 +55,7 @@ void TextRegBits(Emulator* e, u8 v, BitArg arg, Args... args) {
     ImGui::SameLine();
     ImGui::Text("%s", text);
     if (arg.tooltip && ImGui::IsItemHovered()) {
-      ImGui::SetTooltip(arg.tooltip);
+      ImGui::SetTooltip("%s", arg.tooltip);
     }
   }
   TextRegBits(e, v, args...);


### PR DESCRIPTION
The settooltip function expects a format + parameters, and complains with a warning that a direct variable string is provided. This in theory could cause a crash if a % is in a tooltip.