### PR TITLE
Skip loadExtRam when the buffer is empty

### DIFF
--- a/docs/simple.js
+++ b/docs/simple.js
@@ -177,7 +177,7 @@ class Emulator {
     this.fps = 60;
     this.fastForward = false;
 
-    if (extRamBuffer) {
+    if (extRamBuffer && extRamBuffer.byteLength > 0) {
       this.loadExtRam(extRamBuffer);
     }
 


### PR DESCRIPTION
An empty Uint8Array is still truthy, so the constructor's `if (extRamBuffer)` guard called loadExtRam even when there was no save data to restore. For carts that don't advertise external RAM (MBC5 with EXT_RAM_SIZE_NONE, ROM-only, etc.),
`_ext_ram_file_data_new` returns 0 and the wasm side then reads from a null file-data ptr inside `_emulator_read_ext_ram`. Sometimes that lands on valid wasm linear memory, sometimes it's out of bounds depending on heap state from prior alloc/free cycles — surfacing as an intermittent
"RuntimeError: memory access out of bounds" in long-running embed scenarios that recreate the Emulator multiple times.

Tighten the guard to also require `extRamBuffer.byteLength > 0`.