### PR TITLE
Expose window.playROM(bytes) for programmatic ROM loading

### DIFF
--- a/docs/simple.js
+++ b/docs/simple.js
@@ -132,6 +132,19 @@ const vm = new VM();
   emulator.setBuiltinPalette(vm.palIdx);
 })();
 
+// Programmatic entry point for embedders. Pass ROM bytes directly
+// instead of going through the ROM_FILENAME fetch above.
+window.playROM = async function(bytes) {
+  const module = await binjgbPromise;
+  Emulator.start(module, bytes.buffer, new Uint8Array(0));
+  if (emulator) {
+    emulator.setBuiltinPalette(vm.palIdx);
+    if (emulator.audio && typeof emulator.audio.startPlayback === 'function') {
+      emulator.audio.startPlayback();
+    }
+  }
+};
+
 
 // Copied from demo.js
 function makeWasmBuffer(module, ptr, size) {


### PR DESCRIPTION
The hosted demo's auto-load fetches ROM_FILENAME at startup, which is exactly what embedders don't want — they have the ROM bytes already (built in-browser, fetched from somewhere else, hand-edited, etc.) and don't have a server file to point at. Today the only way to play those bytes is to vendor simple.js and edit out the IIFE, which forks the file and makes it harder to track upstream.

Add window.playROM(bytes) as a thin wrapper around Emulator.start that takes a Uint8Array and routes through the same paths the IIFE uses. Synchronous startPlayback() inside the user gesture transient unblocks the AudioContext immediately so the first audible tick doesn't wait on a stray future click.

The auto-load IIFE is left in place so the hosted demo behaves identically. Embedders set ROM_FILENAME to something that 404s (or leave it) and call window.playROM(bytes) once their ROM is ready.