### PR TITLE
Fix SGB ATTR_BLK region rendering

### DIFF
--- a/src/emulator.c
+++ b/src/emulator.c
@@ -2453,16 +2453,32 @@ static void do_sgb(Emulator* e) {
             u8 palin = pal & 3, palon = (pal >> 2) & 3, palout = (pal >> 4) & 3;
             u8 l = SGB.data[4 + i * 6], t = SGB.data[5 + i * 6],
                r = SGB.data[6 + i * 6], b = SGB.data[7 + i * 6];
-            if (info & 1) {  // colors inside region
-              set_sgb_attr_block(e, l, t, r, b, palin);
+            
+            Bool inside = info & 1;
+            Bool border = info & 2;
+            Bool outside = info & 4;
+            
+            if (inside && !border && !outside) {
+              border = TRUE;
+              palon = palin;
+            } else if (outside && !border && !inside) {
+              border = TRUE;
+              palon = palout;
             }
-            if (info & 2) { // colors on region border
+            
+            Bool has_inner = (r - l) >= 2 && (b - t) >= 2;
+            if (inside && has_inner) { // colors inside region
+              set_sgb_attr_block(e, l + 1, t + 1, r - 1, b - 1, palin);
+            }
+
+            if (border) { // colors on region border
               set_sgb_attr_block(e, l, t, r, t, palon);  // top
               set_sgb_attr_block(e, l, t, l, b, palon);  // left
               set_sgb_attr_block(e, l, b, r, b, palon);  // bottom
               set_sgb_attr_block(e, r, t, r, b, palon);  // right
             }
-            if (info & 4) { // colors outside region
+
+            if (outside) { // colors outside region
               set_sgb_attr_block(e, 0, 0, 19, t - 1, palout);   // top
               set_sgb_attr_block(e, 0, t, l - 1, b, palout);    // left
               set_sgb_attr_block(e, 0, b + 1, 19, 17, palout);  // bottom


### PR DESCRIPTION
Properly manage the area border for the fill+outside and outside only cases with the ATTR_BLK command for Super GB mode.

* For the fill+outside the expectation is that the border of the area to not be changed.
* For the outside only case, the border should also use the palette

Here's a comparison between the new version with these changes (left), Sameboy (middle) and the old version without the changes (right)

<img width="1371" height="474" alt="Screenshot 2026-05-25 at 10 47 49" src="https://github.com/user-attachments/assets/bcdfb98b-8406-455b-b66d-47d8d01a54d4" />

<img width="1373" height="480" alt="Screenshot 2026-05-25 at 10 47 26" src="https://github.com/user-attachments/assets/276936cd-1468-4026-b886-b2dc9c674c5b" />



All other cases can be tested with this rom [sgb-test.gb.zip](https://github.com/user-attachments/files/28216060/sgb-test.gb.zip) by pressing A or B to rotate between the different combinations. Also tested with some commercial games and all seems work well. 

